### PR TITLE
feat: update docker structs to be saved to client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build: binary-build
 
 run: build kubernetes-run
 
+docker-test: build docker-run
+
+kubernetes-test: build kubernetes-run
+
 test: build docker-run kubernetes-run
 
 #################################

--- a/cmd/vela-runtime/run.go
+++ b/cmd/vela-runtime/run.go
@@ -127,7 +127,7 @@ func run(c *cli.Context) error {
 		}
 
 		logrus.Infof("creating container for step %s", tmp.Name)
-		err = r.RunContainer(ctx, p, tmp)
+		err = r.RunContainer(ctx, tmp, p)
 		if err != nil {
 			return err
 		}

--- a/runtime/docker/container.go
+++ b/runtime/docker/container.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
 
@@ -85,9 +84,8 @@ func (c *client) RemoveContainer(ctx context.Context, ctn *pipeline.Container) e
 
 // RunContainer creates and start the pipeline container.
 func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *pipeline.Build) error {
-	// create host configuration
-	c.hostConf = hostConfig(b.ID)
-	// create network configuration
+	// create container configuration
+	c.ctnConf = ctnConfig(ctn)
 	c.netConf = netConfig(b.ID, ctn.Name)
 
 	logrus.Tracef("Creating container for step %s", b.ID)
@@ -121,9 +119,6 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 // SetupContainer pulls the image for the pipeline container.
 func (c *client) SetupContainer(ctx context.Context, ctn *pipeline.Container) error {
 	logrus.Tracef("Parsing image %s", ctn.Image)
-
-	// create container configuration
-	c.ctnConf = ctnConfig(ctn)
 
 	// parse image from container
 	image, err := parseImage(ctn.Image)
@@ -288,22 +283,4 @@ func ctnConfig(ctn *pipeline.Container) *container.Config {
 	}
 
 	return config
-}
-
-// hostConfig is a helper function to generate
-// the host config for a container.
-func hostConfig(id string) *container.HostConfig {
-	return &container.HostConfig{
-		LogConfig: container.LogConfig{
-			Type: "json-file",
-		},
-		Privileged: false,
-		Mounts: []mount.Mount{
-			{
-				Type:   mount.TypeVolume,
-				Source: id,
-				Target: "/home",
-			},
-		},
-	}
 }

--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -79,13 +79,13 @@ func TestDocker_RunContainer_Success(t *testing.T) {
 
 	// run test
 	got := c.RunContainer(context.Background(),
-		&pipeline.Build{
-			Version: "1",
-			ID:      "__0",
-		},
 		&pipeline.Container{
 			ID:    "container_id",
 			Image: "alpine:latest",
+		},
+		&pipeline.Build{
+			Version: "1",
+			ID:      "__0",
 		})
 
 	if got != nil {
@@ -105,8 +105,8 @@ func TestDocker_RunContainer_Failure(t *testing.T) {
 
 	// run test
 	got := c.RunContainer(context.Background(),
-		&pipeline.Build{},
-		&pipeline.Container{})
+		&pipeline.Container{},
+		&pipeline.Build{})
 
 	// this should be "=="
 	if got != nil {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -5,6 +5,8 @@
 package docker
 
 import (
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
 	"github.com/go-vela/pkg-runtime/runtime/docker/testdata/mock"
 	"github.com/sirupsen/logrus"
@@ -14,6 +16,10 @@ const dockerVersion = "1.38"
 
 type client struct {
 	Runtime *docker.Client
+
+	ctnConf  *container.Config
+	hostConf *container.HostConfig
+	netConf  *network.NetworkingConfig
 }
 
 // New returns an Engine implementation that
@@ -27,14 +33,17 @@ func New() (*client, error) {
 	// pin version to prevent "client version <version> is too new." errors
 	// typically this would be inherited from the host env but this will ensure
 	// we know what version of the Docker API we're using
-	docker.WithVersion(dockerVersion)(r)
-
-	// create the client object
-	c := &client{
-		Runtime: r,
+	err = docker.WithVersion(dockerVersion)(r)
+	if err != nil {
+		return nil, err
 	}
 
-	return c, nil
+	return &client{
+		Runtime:  r,
+		ctnConf:  new(container.Config),
+		hostConf: new(container.HostConfig),
+		netConf:  new(network.NetworkingConfig),
+	}, nil
 }
 
 // NewMock returns an Engine implementation that

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -7,6 +7,8 @@ package docker
 import (
 	"context"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	types "github.com/docker/docker/api/types/volume"
 	"github.com/go-vela/types/pipeline"
 	"github.com/sirupsen/logrus"
@@ -15,6 +17,9 @@ import (
 // CreateVolume creates the pipeline volume.
 func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 	logrus.Tracef("Creating volume for pipeline %s", b.ID)
+
+	// create host configuration
+	c.hostConf = hostConfig(b.ID)
 
 	// create options for creating volume
 	opts := types.VolumeCreateBody{
@@ -55,4 +60,22 @@ func (c *client) RemoveVolume(ctx context.Context, b *pipeline.Build) error {
 	}
 
 	return nil
+}
+
+// hostConfig is a helper function to generate
+// the host config with volume specification for a container.
+func hostConfig(id string) *container.HostConfig {
+	return &container.HostConfig{
+		LogConfig: container.LogConfig{
+			Type: "json-file",
+		},
+		Privileged: false,
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeVolume,
+				Source: id,
+				Target: "/home",
+			},
+		},
+	}
 }

--- a/runtime/engine.go
+++ b/runtime/engine.go
@@ -25,7 +25,7 @@ type Engine interface {
 	RemoveContainer(context.Context, *pipeline.Container) error
 	// RunContainer defines a function that creates
 	// and start the pipeline container.
-	RunContainer(context.Context, *pipeline.Build, *pipeline.Container) error
+	RunContainer(context.Context, *pipeline.Container, *pipeline.Build) error
 	// SetupContainer defines a function that pulls
 	// the image for the pipeline container.
 	SetupContainer(context.Context, *pipeline.Container) error

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -99,7 +99,7 @@ func (c *client) RemoveContainer(ctx context.Context, ctn *pipeline.Container) e
 }
 
 // RunContainer creates and start the pipeline container.
-func (c *client) RunContainer(ctx context.Context, b *pipeline.Build, ctn *pipeline.Container) error {
+func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *pipeline.Build) error {
 	logrus.Tracef("running container %s", ctn.ID)
 
 	// TODO: investigate way to move this logic


### PR DESCRIPTION
We have an established pattern of saving structs to clients for passing common data between methods on clients. This functionality brings the Docker runtime in sync with the Kubernetes pattern