### PR TITLE
feat: enable setting host volumes

### DIFF
--- a/internal/volume/doc.go
+++ b/internal/volume/doc.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package volume provides the ability for Vela to manage
+// and manipulate a volume provided for a container.
+//
+// Usage:
+//
+// 	import "github.com/go-vela/pkg-runtime/internal/volume"
+package volume

--- a/internal/volume/volume.go
+++ b/internal/volume/volume.go
@@ -32,10 +32,6 @@ func Parse(_volume string) *Volume {
 	return v
 }
 
-// Parse digests the provided volume into a fully
-// qualified volume reference. If an error
-// occurs, it will return the provided volume.
-
 // ParseWithError digests the provided volume into a
 // fully qualified volume reference. If an error
 // occurs, it will return a nil volume and the

--- a/internal/volume/volume.go
+++ b/internal/volume/volume.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package volume
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Volume represents the volume definition used
+// to create volumes for a container.
+type Volume struct {
+	Source      string `json:"source,omitempty"`
+	Destination string `json:"destination,omitempty"`
+	AccessMode  string `json:"access_mode,omitempty"`
+}
+
+// Parse digests the provided volume into a fully
+// qualified volume reference. If an error
+// occurs, it will return a nil volume.
+func Parse(_volume string) *Volume {
+	// parse the image provided into a fully qualified canonical reference
+	//
+	// https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime/internal/image?tab=doc#ParseWithError
+	v, err := ParseWithError(_volume)
+	if err != nil {
+		return nil
+	}
+
+	return v
+}
+
+// Parse digests the provided volume into a fully
+// qualified volume reference. If an error
+// occurs, it will return the provided volume.
+
+// ParseWithError digests the provided volume into a
+// fully qualified volume reference. If an error
+// occurs, it will return a nil volume and the
+// produced error.
+func ParseWithError(_volume string) (*Volume, error) {
+	// split each slice element into source, destination and access mode
+	parts := strings.Split(_volume, ":")
+
+	switch len(parts) {
+	case 1:
+		// return the read-only volume with the same source and destination
+		return &Volume{
+			Source:      parts[0],
+			Destination: parts[0],
+			AccessMode:  "ro",
+		}, nil
+	case 2:
+		// return the read-only volume with different source and destination
+		return &Volume{
+			Source:      parts[0],
+			Destination: parts[1],
+			AccessMode:  "ro",
+		}, nil
+	case 3:
+		// return the full volume with source, destination and access mode
+		return &Volume{
+			Source:      parts[0],
+			Destination: parts[1],
+			AccessMode:  parts[2],
+		}, nil
+	default:
+		return nil, fmt.Errorf("volume %s requires at least 1, but no more than 2, `:`", _volume)
+	}
+}

--- a/internal/volume/volume_test.go
+++ b/internal/volume/volume_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package volume
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVolume_Parse(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		volume string
+		want   *Volume
+	}{
+		{
+			volume: "/foo",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/foo",
+				AccessMode:  "ro",
+			},
+		},
+		{
+			volume: "/foo:/bar",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/bar",
+				AccessMode:  "ro",
+			},
+		},
+		{
+			volume: "/foo:/bar:ro",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/bar",
+				AccessMode:  "ro",
+			},
+		},
+		{
+			volume: "/foo:/bar:rw",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/bar",
+				AccessMode:  "rw",
+			},
+		},
+		{
+			volume: "/foo:/bar:/foo:bar",
+			want:   nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := Parse(test.volume)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Parse is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestImage_ParseWithError(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure bool
+		volume  string
+		want    *Volume
+	}{
+		{
+			failure: false,
+			volume:  "/foo",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/foo",
+				AccessMode:  "ro",
+			},
+		},
+		{
+			failure: false,
+			volume:  "/foo:/bar",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/bar",
+				AccessMode:  "ro",
+			},
+		},
+		{
+			failure: false,
+			volume:  "/foo:/bar:ro",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/bar",
+				AccessMode:  "ro",
+			},
+		},
+		{
+			failure: false,
+			volume:  "/foo:/bar:rw",
+			want: &Volume{
+				Source:      "/foo",
+				Destination: "/bar",
+				AccessMode:  "rw",
+			},
+		},
+		{
+			failure: true,
+			volume:  "/foo:/bar:/foo:bar",
+			want:    nil,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got, err := ParseWithError(test.volume)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("ParseWithError should have returned err")
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("ParseWithError is %s want %s", got, test.want)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("ParseWithError returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("ParseWithError is %v, want %v", got, test.want)
+		}
+	}
+}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -25,11 +25,14 @@ type client struct {
 	hostConf *container.HostConfig
 	// https://godoc.org/github.com/docker/docker/api/types/network#NetworkingConfig
 	netConf *network.NetworkingConfig
+
+	// set of host volumes to mount into every container
+	volumes []string
 }
 
 // New returns an Engine implementation that
 // integrates with a Docker runtime.
-func New() (*client, error) {
+func New(_volumes []string) (*client, error) {
 	// create Docker client from environment
 	//
 	// https://godoc.org/github.com/docker/docker/client#NewClientWithOpts
@@ -51,6 +54,7 @@ func New() (*client, error) {
 		ctnConf:  new(container.Config),
 		hostConf: new(container.HostConfig),
 		netConf:  new(network.NetworkingConfig),
+		volumes:  _volumes,
 	}, nil
 }
 

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -38,7 +38,7 @@ func TestDocker_New(t *testing.T) {
 		// patch environment for tests
 		env.PatchAll(t, test.envs)
 
-		_, err := New()
+		_, err := New(nil)
 
 		if test.failure {
 			if err == nil {

--- a/runtime/flags.go
+++ b/runtime/flags.go
@@ -43,4 +43,9 @@ var Flags = []cli.Flag{
 		Name:    "runtime.namespace",
 		Usage:   "name of namespace for runtime configuration (kubernetes runtime only)",
 	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_RUNTIME_VOLUMES", "RUNTIME_VOLUMES"},
+		Name:    "runtime.volumes",
+		Usage:   "set of volumes to mount into the runtime",
+	},
 }

--- a/runtime/flags.go
+++ b/runtime/flags.go
@@ -43,7 +43,7 @@ var Flags = []cli.Flag{
 		Name:    "runtime.namespace",
 		Usage:   "name of namespace for runtime configuration (kubernetes runtime only)",
 	},
-	&cli.StringFlag{
+	&cli.StringSliceFlag{
 		EnvVars: []string{"VELA_RUNTIME_VOLUMES", "RUNTIME_VOLUMES"},
 		Name:    "runtime.volumes",
 		Usage:   "set of volumes to mount into the runtime",

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-vela/pkg-runtime/internal/image"
+	vol "github.com/go-vela/pkg-runtime/internal/volume"
 	"github.com/go-vela/types/pipeline"
 
 	"github.com/sirupsen/logrus"
@@ -117,6 +118,21 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 					Name:      b.ID,
 					MountPath: "/vela",
 				},
+			}
+
+			// check if other volumes were provided
+			if len(c.volumes) > 0 {
+				// iterate through all volumes provided
+				for k, v := range c.volumes {
+					// parse the volume provided
+					_volume := vol.Parse(v)
+
+					// add the volume to the container
+					container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
+						Name:      fmt.Sprintf("%s_%d", b.ID, k),
+						MountPath: _volume.Destination,
+					})
+				}
 			}
 		}
 

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -17,11 +17,14 @@ type client struct {
 
 	namespace string
 	pod       *v1.Pod
+
+	// set of host volumes to mount into every container
+	volumes []string
 }
 
 // New returns an Engine implementation that
 // integrates with a Kubernetes runtime.
-func New(namespace, path string) (*client, error) {
+func New(namespace, path string, _volumes []string) (*client, error) {
 	// use the current context in kubeconfig
 	//
 	// when kube config is provided use out of cluster config option else
@@ -48,6 +51,7 @@ func New(namespace, path string) (*client, error) {
 			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 		},
 		kubernetes: _kubernetes,
+		volumes:    _volumes,
 	}, nil
 }
 

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -34,7 +34,7 @@ func TestKubernetes_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err := New(test.namespace, test.path)
+		_, err := New(test.namespace, test.path, nil)
 
 		if test.failure {
 			if err == nil {

--- a/runtime/setup.go
+++ b/runtime/setup.go
@@ -23,6 +23,7 @@ type Setup struct {
 	Driver    string
 	Config    string
 	Namespace string
+	Volumes   []string
 }
 
 // Docker creates and returns a Vela engine capable of
@@ -33,7 +34,7 @@ func (s *Setup) Docker() (Engine, error) {
 	// create new Docker runtime engine
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime/docker?tab=doc#New
-	return docker.New()
+	return docker.New(s.Volumes)
 }
 
 // Kubernetes creates and returns a Vela engine capable of
@@ -44,7 +45,7 @@ func (s *Setup) Kubernetes() (Engine, error) {
 	// create new Kubernetes runtime engine
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime/kubernetes?tab=doc#New
-	return kubernetes.New(s.Namespace, s.Config)
+	return kubernetes.New(s.Namespace, s.Config, s.Volumes)
 }
 
 // Validate verifies the necessary fields for the


### PR DESCRIPTION
This PR enables setting volumes on the host that will be mounted into every container during the execution of the pipeline.

Currently, our primary use-case for this feature would be to mount SSL certificates from the host into each container.

This is accomplished by passing the `runtime.volumes` flag directly to the library.

That flag is also configurable via the `VELA_RUNTIME_VOLUMES` or `RUNTIME_VOLUMES` environment variable.