### PR TITLE
fix: skip image inspect for on_start pull policy

### DIFF
--- a/runtime/docker/image.go
+++ b/runtime/docker/image.go
@@ -6,11 +6,14 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/go-vela/pkg-runtime/internal/image"
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 
 	"github.com/sirupsen/logrus"
@@ -62,6 +65,11 @@ func (c *client) InspectImage(ctx context.Context, ctn *pipeline.Container) ([]b
 	_image, err := image.ParseWithError(ctn.Image)
 	if err != nil {
 		return nil, err
+	}
+
+	// check if the container pull policy is on start
+	if strings.EqualFold(ctn.Pull, constants.PullOnStart) {
+		return []byte(fmt.Sprintf("skipped for container %s due to pull policy %s\n", ctn.ID, ctn.Pull)), nil
 	}
 
 	// send API call to inspect the image


### PR DESCRIPTION
Part of the effort for go-vela/community#104

Continuation of https://github.com/go-vela/pkg-runtime/pull/56

Previously, we always pulled the Docker images for all steps in a pipeline during the `init` step.

We then inspect the contents of each step image and output them in the `init` logs.

With these new pull policies, that's not always the case specifically with `on_start` and `never`.

This PR will skip inspecting the image if an `on_start` pull policy is used 👍 

The reason we don't skip inspecting the image if a `never` pull policy is used is because the worker should be able to assume that the image already exists on the host 👍 