### PR TITLE
fix: skip closing read buffer and manually close other buffers

### DIFF
--- a/runtime/docker/container.go
+++ b/runtime/docker/container.go
@@ -226,15 +226,6 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 	go func() {
 		logrus.Tracef("copying logs for container %s", ctn.ID)
 
-		// defer closing all buffers
-		defer func() {
-			// close logs buffer
-			logs.Close()
-
-			// close in-memory pipe write closer
-			wc.Close()
-		}()
-
 		// copy container stdout and stderr logs to our in-memory pipe
 		//
 		// https://godoc.org/github.com/docker/docker/pkg/stdcopy#StdCopy
@@ -242,6 +233,12 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 		if err != nil {
 			logrus.Errorf("unable to copy logs for container: %v", err)
 		}
+
+		// close logs buffer
+		logs.Close()
+
+		// close in-memory pipe write closer
+		wc.Close()
 	}()
 
 	return rc, nil

--- a/runtime/docker/container.go
+++ b/runtime/docker/container.go
@@ -222,10 +222,10 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 	// create in-memory pipe for capturing logs
 	rc, wc := io.Pipe()
 
-	logrus.Tracef("copying logs for container %s", ctn.ID)
-
 	// capture all stdout and stderr logs
 	go func() {
+		logrus.Tracef("copying logs for container %s", ctn.ID)
+
 		// defer closing all buffers
 		defer func() {
 			// close logs buffer
@@ -233,9 +233,6 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 
 			// close in-memory pipe write closer
 			wc.Close()
-
-			// close in-memory pipe read closer
-			rc.Close()
 		}()
 
 		// copy container stdout and stderr logs to our in-memory pipe


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/128

The important part of this PR is skipping the closing of the read buffer:

* [removal of `rc.Close()`](https://github.com/go-vela/pkg-runtime/blob/48a91e671e80d97b4ae840a6e062cb83431744da/runtime/docker/container.go#L237-L238)

The closing of the read buffer is actually duplicate code that we already call in [go-vela/pkg-executor](https://github.com/go-vela/pkg-executor):

* [calling of `rc.Close()`](https://github.com/go-vela/pkg-executor/blob/6d4942e1950fac6fb9a07c9b45eba14304220a93/executor/linux/step.go#L256)

The end result is this change should now prevent error messages like:

```
io: read/write on closed pipe
```

We saw this error because we are closing the read buffer in the runtime before the executor finished reading from that buffer.