### PR TITLE
feat: add runtime.Driver() function

### DIFF
--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -74,7 +74,7 @@ func NewMock() (*client, error) {
 	// create the client object
 	c := &client{
 		docker:           _docker,
-		privilegedImages: []string{},
+		privilegedImages: []string{"target/vela-git"},
 	}
 
 	return c, nil

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -74,7 +74,7 @@ func NewMock() (*client, error) {
 	// create the client object
 	c := &client{
 		docker:           _docker,
-		privilegedImages: []string{"target/vela-git"},
+		privilegedImages: []string{},
 	}
 
 	return c, nil

--- a/runtime/docker/driver.go
+++ b/runtime/docker/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package docker
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured runtime driver.
+func (c *client) Driver() string {
+	return constants.DriverDocker
+}

--- a/runtime/docker/driver_test.go
+++ b/runtime/docker/driver_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package docker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/constants"
+)
+
+func TestDocker_Driver(t *testing.T) {
+	// setup types
+	want := constants.DriverDocker
+
+	_engine, err := NewMock()
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// run tes
+	got := _engine.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}

--- a/runtime/engine.go
+++ b/runtime/engine.go
@@ -15,6 +15,12 @@ import (
 // with the different supported Runtime environments.
 type Engine interface {
 
+	// Engine Interface Functions
+
+	// Driver defines a function that outputs
+	// the configured runtime driver.
+	Driver() string
+
 	// Container Engine Interface Functions
 
 	// InspectContainer defines a function that inspects

--- a/runtime/kubernetes/driver.go
+++ b/runtime/kubernetes/driver.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package kubernetes
+
+import "github.com/go-vela/types/constants"
+
+// Driver outputs the configured runtime driver.
+func (c *client) Driver() string {
+	return constants.DriverKubernetes
+}

--- a/runtime/kubernetes/driver_test.go
+++ b/runtime/kubernetes/driver_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/constants"
+)
+
+func TestKubernetes_Driver(t *testing.T) {
+	// setup types
+	want := constants.DriverKubernetes
+
+	_engine, err := NewMock(_pod)
+	if err != nil {
+		t.Errorf("unable to create runtime engine: %v", err)
+	}
+
+	// run tes
+	got := _engine.Driver()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Driver is %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This updates the `go-vela/pkg-runtime/runtime.Engine` interface to include a `Driver()` function:

https://github.com/go-vela/pkg-runtime/blob/f33ebcdd7fab2b59b0afb8e5a691ef34e1f4010e/runtime/engine.go#L20-L22

And then we implement this function for each supported runtime:

https://github.com/go-vela/pkg-runtime/blob/f33ebcdd7fab2b59b0afb8e5a691ef34e1f4010e/runtime/docker/driver.go#L9-L12

https://github.com/go-vela/pkg-runtime/blob/f33ebcdd7fab2b59b0afb8e5a691ef34e1f4010e/runtime/kubernetes/driver.go#L9-L12


