### PR TITLE
refactor: update inspect output with commands

### DIFF
--- a/runtime/docker/network.go
+++ b/runtime/docker/network.go
@@ -7,6 +7,7 @@ package docker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
@@ -47,12 +48,17 @@ func (c *client) InspectNetwork(ctx context.Context, b *pipeline.Build) ([]byte,
 	// https://godoc.org/github.com/docker/docker/api/types#NetworkInspectOptions
 	opts := types.NetworkInspectOptions{}
 
+	// create output for inspecting network
+	output := []byte(
+		fmt.Sprintf("$ docker network inspect %s\n", b.ID),
+	)
+
 	// send API call to inspect the network
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.NetworkInspect
 	n, err := c.docker.NetworkInspect(ctx, b.ID, opts)
 	if err != nil {
-		return nil, err
+		return output, err
 	}
 
 	// convert network type NetworkResource to bytes with pretty print
@@ -60,11 +66,11 @@ func (c *client) InspectNetwork(ctx context.Context, b *pipeline.Build) ([]byte,
 	// https://godoc.org/github.com/docker/docker/api/types#NetworkResource
 	network, err := json.MarshalIndent(n, "", " ")
 	if err != nil {
-		return nil, err
+		return output, err
 	}
 
 	// add new line to end of bytes
-	return append(network, "\n"...), nil
+	return append(output, append(network, "\n"...)...), nil
 }
 
 // RemoveNetwork deletes the pipeline network.

--- a/runtime/kubernetes/image.go
+++ b/runtime/kubernetes/image.go
@@ -44,6 +44,7 @@ func (c *client) InspectImage(ctx context.Context, ctn *pipeline.Container) ([]b
 	//
 	// create output for inspecting image
 	output := []byte(
+		// nolint: lll // ignore line length due to string formatting with parameters
 		fmt.Sprintf("$ kubectl get pod -o=jsonpath='{.spec.containers[%d].image}' %s\n", ctn.Number, ctn.ID),
 	)
 

--- a/runtime/kubernetes/image.go
+++ b/runtime/kubernetes/image.go
@@ -6,7 +6,11 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 
 	"github.com/sirupsen/logrus"
@@ -36,5 +40,26 @@ func (c *client) CreateImage(ctx context.Context, ctn *pipeline.Container) error
 func (c *client) InspectImage(ctx context.Context, ctn *pipeline.Container) ([]byte, error) {
 	logrus.Tracef("inspecting image for container %s", ctn.ID)
 
-	return nil, nil
+	// TODO: consider updating this command
+	//
+	// create output for inspecting image
+	output := []byte(
+		fmt.Sprintf("$ kubectl get pod -o=jsonpath='{.spec.containers[%d].image}' %s\n", ctn.Number, ctn.ID),
+	)
+
+	// check if the container pull policy is on start
+	if strings.EqualFold(ctn.Pull, constants.PullOnStart) {
+		return []byte(
+			fmt.Sprintf("skipped for container %s due to pull policy %s\n", ctn.ID, ctn.Pull),
+		), nil
+	}
+
+	// marshal the image information from the container
+	image, err := json.MarshalIndent(c.pod.Spec.Containers[ctn.Number-2].Image, "", " ")
+	if err != nil {
+		return output, err
+	}
+
+	// add new line to end of bytes
+	return append(output, append(image, "\n"...)...), nil
 }

--- a/runtime/kubernetes/network.go
+++ b/runtime/kubernetes/network.go
@@ -90,13 +90,20 @@ func (c *client) CreateNetwork(ctx context.Context, b *pipeline.Build) error {
 func (c *client) InspectNetwork(ctx context.Context, b *pipeline.Build) ([]byte, error) {
 	logrus.Tracef("inspecting network for pipeline %s", b.ID)
 
+	// TODO: consider updating this command
+	//
+	// create output for inspecting volume
+	output := []byte(
+		fmt.Sprintf("$ kubectl get pod -o=jsonpath='{.spec.hostAliases}' %s\n", b.ID),
+	)
+
 	// marshal the network information from the pod
-	bytes, err := json.Marshal(c.pod.Spec.HostAliases)
+	network, err := json.MarshalIndent(c.pod.Spec.HostAliases, "", " ")
 	if err != nil {
-		return nil, err
+		return output, err
 	}
 
-	return bytes, nil
+	return append(output, append(network, "\n"...)...), nil
 }
 
 // RemoveNetwork deletes the pipeline network.

--- a/runtime/kubernetes/network_test.go
+++ b/runtime/kubernetes/network_test.go
@@ -6,8 +6,6 @@ package kubernetes
 
 import (
 	"context"
-	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/go-vela/types/pipeline"
@@ -60,11 +58,6 @@ func TestKubernetes_InspectNetwork(t *testing.T) {
 		t.Errorf("unable to create runtime engine: %v", err)
 	}
 
-	want, err := json.Marshal(_pod.Spec.HostAliases)
-	if err != nil {
-		t.Errorf("unable to marshal pod network: %v", err)
-	}
-
 	// setup tests
 	tests := []struct {
 		failure  bool
@@ -82,7 +75,7 @@ func TestKubernetes_InspectNetwork(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got, err := _engine.InspectNetwork(context.Background(), test.pipeline)
+		_, err = _engine.InspectNetwork(context.Background(), test.pipeline)
 
 		if test.failure {
 			if err == nil {
@@ -94,10 +87,6 @@ func TestKubernetes_InspectNetwork(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("InspectNetwork returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("InspectNetwork is %v, want %v", string(got), string(want))
 		}
 	}
 }

--- a/runtime/kubernetes/volume.go
+++ b/runtime/kubernetes/volume.go
@@ -74,13 +74,20 @@ func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 func (c *client) InspectVolume(ctx context.Context, b *pipeline.Build) ([]byte, error) {
 	logrus.Tracef("inspecting volume for pipeline %s", b.ID)
 
+	// TODO: consider updating this command
+	//
+	// create output for inspecting volume
+	output := []byte(
+		fmt.Sprintf("$ kubectl get pod -o=jsonpath='{.spec.volumes}' %s\n", b.ID),
+	)
+
 	// marshal the volume information from the pod
-	bytes, err := json.Marshal(c.pod.Spec.Volumes)
+	volume, err := json.MarshalIndent(c.pod.Spec.Volumes, "", " ")
 	if err != nil {
 		return nil, err
 	}
 
-	return bytes, nil
+	return append(output, append(volume, "\n"...)...), nil
 }
 
 // RemoveVolume deletes the pipeline volume.

--- a/runtime/kubernetes/volume_test.go
+++ b/runtime/kubernetes/volume_test.go
@@ -6,8 +6,6 @@ package kubernetes
 
 import (
 	"context"
-	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/go-vela/types/pipeline"
@@ -56,12 +54,6 @@ func TestKubernetes_CreateVolume(t *testing.T) {
 }
 
 func TestKubernetes_InspectVolume(t *testing.T) {
-	// setup types
-	want, err := json.Marshal(_pod.Spec.Volumes)
-	if err != nil {
-		t.Errorf("unable to marshal pod volumes: %v", err)
-	}
-
 	// setup tests
 	tests := []struct {
 		failure  bool
@@ -87,7 +79,7 @@ func TestKubernetes_InspectVolume(t *testing.T) {
 			t.Errorf("unable to create runtime engine: %v", err)
 		}
 
-		got, err := _engine.InspectVolume(context.Background(), test.pipeline)
+		_, err = _engine.InspectVolume(context.Background(), test.pipeline)
 
 		if test.failure {
 			if err == nil {
@@ -99,10 +91,6 @@ func TestKubernetes_InspectVolume(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("InspectVolume returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("InspectVolume is %v, want %v", string(got), string(want))
 		}
 	}
 }


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This updates the output for the `Inspect()` functions to include the command executed for that resource.

i.e.

```
$ docker network inspect <network>
<network_information>
```

Today, there is [code in the go-vela/pkg-executor](https://github.com/go-vela/pkg-executor/blob/master/executor/linux/build.go#L115-L126) codebase that has these commands hardcoded:

```go
	// inspect the runtime network for the pipeline
	network, err := c.Runtime.InspectNetwork(ctx, c.pipeline)
	if err != nil {
		c.err = err
		return fmt.Errorf("unable to inspect network: %w", err)
	}

	// update the init log with network command
	//
	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
	_log.AppendData([]byte(fmt.Sprintf("$ docker network inspect %s \n", c.pipeline.ID)))
	_log.AppendData(network)
```

The problem is if you use a [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime) beyond `docker`. the init logs will be inaccurate since they are hardcoded.

After this is merged, we can update the above code to look something like this:

```go
	// inspect the runtime network for the pipeline
	network, err := c.Runtime.InspectNetwork(ctx, c.pipeline)
	if err != nil {
		c.err = err
		return fmt.Errorf("unable to inspect network: %w", err)
	}

	// update the init log with network information
	//
	// https://pkg.go.dev/github.com/go-vela/types/library?tab=doc#Log.AppendData
	_log.AppendData(network)
```

This will make [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime) responsible for returning the proper command output based off the runtime being used. 