### PR TITLE
refactor: use workspace constants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-vela/compiler v0.7.0-rc1
 	github.com/go-vela/mock v0.7.0-rc1
-	github.com/go-vela/types v0.7.0-rc1
+	github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/joho/godotenv v1.3.0
@@ -19,6 +19,7 @@ require (
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/genproto v0.0.0-20201013134114-7f9ee70cb474 // indirect
 	gotest.tools/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/go-vela/mock v0.7.0-rc1 h1:Rhb5XWYNxAlL0Nus9CEwrlWx4xOQTwKImKt0xc4i8R
 github.com/go-vela/mock v0.7.0-rc1/go.mod h1:diiACzMDRowQH/ayauz7c7YSRsqOHwaoC8V0rgO3qIs=
 github.com/go-vela/types v0.7.0-rc1 h1:Q16xpyfLD3uc20mDimidjQoSwi7HG7ukfYJs74I/XHY=
 github.com/go-vela/types v0.7.0-rc1/go.mod h1:ATtwTwp2l4jI4GUmw840xHZgHmg8FbZPo4g0azImggA=
+github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d h1:TJ6ZOLmPN02UcDDJNnzDlYNB3xwev6mojN7ekvV+ZXI=
+github.com/go-vela/types v0.7.0-rc1.0.20210115155442-682d1037e16d/go.mod h1:ATtwTwp2l4jI4GUmw840xHZgHmg8FbZPo4g0azImggA=
 github.com/goccy/go-yaml v1.8.4 h1:AOEdR7aQgbgwHznGe3BLkDQVujxCPUpHOZZcQcp8Y3M=
 github.com/goccy/go-yaml v1.8.4/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -493,6 +495,8 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061 h1:DQmQoKxQWtyybCtX/3dIuDBcAhFszqq8YiNeS6sNu1c=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/volume"
 
 	vol "github.com/go-vela/pkg-runtime/internal/volume"
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 
 	"github.com/sirupsen/logrus"
@@ -93,7 +94,7 @@ func hostConfig(id string, volumes []string) *container.HostConfig {
 		{
 			Type:   mount.TypeVolume,
 			Source: id,
-			Target: "/vela",
+			Target: constants.WorkspaceMount,
 		},
 	}
 

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -117,7 +117,7 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 			container.VolumeMounts = []v1.VolumeMount{
 				{
 					Name:      b.ID,
-					MountPath: "/vela",
+					MountPath: constants.WorkspaceMount,
 				},
 			}
 


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

See https://github.com/go-vela/types/pull/135 for more information

This utilizes constants for setting the workspace mount rather then hardcoding it.