### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,29 +51,74 @@ cd $HOME/go-vela/pkg-runtime
 git remote add fork https://github.com/your_fork/pkg-runtime
 ```
 
-### Running Locally
+### Development
 
 * Navigate to the repository code:
 
 ```bash
-# Change into the project directory
+# change into the project directory
 cd $HOME/go-vela/pkg-runtime
 ```
 
-* Build the repository code:
+* Write your code and tests to implement the changes you desire.
+  * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
+
+* Test the repository code (ensures your changes don't break existing functionality):
 
 ```bash
-# Build the code with `make`
-make build
+# execute the `test` target with `make`
+make test
 ```
 
-* Run the repository code:
+* Clean the repository code (ensures your code meets the project standards):
 
 ```bash
-# Run the code with `make`
-make run
+# execute the `clean` target with `make`
+make clean
 ```
 
-### Development
+* Push to your fork:
 
-coming soon!
+```bash
+# push your code up to your fork
+git push fork master
+```
+
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -131,7 +131,9 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo
         - gomnd
+        - lll

--- a/cmd/vela-runtime/resource.go
+++ b/cmd/vela-runtime/resource.go
@@ -29,6 +29,7 @@ func setupBuild() *library.Build {
 	b.SetCreated(time.Now().UTC().Unix())
 	b.SetDeploy("")
 	b.SetClone("https://github.com/go-vela/pkg-runtime.git")
+	// nolint: lll // ignore long line length due to link
 	b.SetSource("https://github.com/go-vela/pkg-runtime/commit/0a08eb2eea09dd58498a4325fee0cb0ab3b66fc9")
 	b.SetTitle("push received from https://github.com/go-vela/pkg-runtime")
 	b.SetMessage("initial commit")
@@ -58,6 +59,7 @@ func setupRepo() *library.Repo {
 	r.SetLink("https://github.com/go-vela/pkg-runtime")
 	r.SetClone("https://github.com/go-vela/pkg-runtime.git")
 	r.SetBranch("master")
+	// nolint: gomnd // ignore magic number
 	r.SetTimeout(30)
 	r.SetVisibility("public")
 	r.SetPrivate(false)

--- a/cmd/vela-runtime/run.go
+++ b/cmd/vela-runtime/run.go
@@ -18,6 +18,8 @@ import (
 )
 
 // run executes the package based off the configuration provided.
+//
+// nolint: funlen // ignore function length due to comments
 func run(c *cli.Context) error {
 	// set the log level for the plugin
 	switch c.String("runtime.log.level") {
@@ -79,6 +81,8 @@ func run(c *cli.Context) error {
 	defer func() {
 		for _, step := range p.Steps {
 			// TODO: remove hardcoded reference
+			//
+			// nolint: goconst // ignore init as constant
 			if step.Name == "init" {
 				continue
 			}

--- a/internal/volume/volume.go
+++ b/internal/volume/volume.go
@@ -48,6 +48,7 @@ func ParseWithError(_volume string) (*Volume, error) {
 			Destination: parts[0],
 			AccessMode:  "ro",
 		}, nil
+	// nolint: gomnd // ignore magic number
 	case 2:
 		// return the read-only volume with different source and destination
 		return &Volume{
@@ -55,6 +56,7 @@ func ParseWithError(_volume string) (*Volume, error) {
 			Destination: parts[1],
 			AccessMode:  "ro",
 		}, nil
+	// nolint: gomnd // ignore magic number
 	case 3:
 		// return the full volume with source, destination and access mode
 		return &Volume{

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -53,6 +53,8 @@ func FromGinContext(c *gin.Context) Engine {
 // WithContext inserts the runtime Engine into the context.Context.
 func WithContext(c context.Context, e Engine) context.Context {
 	// set the runtime Engine in the context.Context
+	//
+	// nolint: golint,staticcheck // ignore using string with context value
 	return context.WithValue(c, key, e)
 }
 

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -29,6 +29,7 @@ func TestRuntime_FromContext(t *testing.T) {
 		want    Engine
 	}{
 		{
+			// nolint: golint,staticcheck // ignore using string with context value
 			context: context.WithValue(context.Background(), key, _engine),
 			want:    _engine,
 		},
@@ -37,6 +38,7 @@ func TestRuntime_FromContext(t *testing.T) {
 			want:    nil,
 		},
 		{
+			// nolint: golint,staticcheck // ignore using string with context value
 			context: context.WithValue(context.Background(), key, "foo"),
 			want:    nil,
 		},
@@ -107,6 +109,7 @@ func TestRuntime_WithContext(t *testing.T) {
 		t.Errorf("unable to create runtime engine: %v", err)
 	}
 
+	// nolint: golint,staticcheck // ignore using string with context value
 	want := context.WithValue(context.Background(), key, _engine)
 
 	// run test

--- a/runtime/docker/container.go
+++ b/runtime/docker/container.go
@@ -100,7 +100,8 @@ func (c *client) RemoveContainer(ctx context.Context, ctn *pipeline.Container) e
 }
 
 // RunContainer creates and starts the pipeline container.
-// nolint // ignore the function length
+//
+// nolint: lll // ignore long line length due to variable names
 func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *pipeline.Build) error {
 	logrus.Tracef("running container %s", ctn.ID)
 
@@ -213,6 +214,8 @@ func (c *client) SetupContainer(ctx context.Context, ctn *pipeline.Container) er
 }
 
 // TailContainer captures the logs for the pipeline container.
+//
+// nolint: lll // ignore long line length due to variable names
 func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io.ReadCloser, error) {
 	logrus.Tracef("tailing output for container %s", ctn.ID)
 

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -12,7 +12,7 @@ import (
 	mock "github.com/go-vela/mock/docker"
 )
 
-// expected version for the Docker API
+// expected version for the Docker API.
 const version = "1.40"
 
 type client struct {
@@ -34,7 +34,8 @@ type client struct {
 
 // New returns an Engine implementation that
 // integrates with a Docker runtime.
-// nolint // ignore client error claiming it's annoying usage
+//
+// nolint: golint // ignore returning unexported client
 func New(_volumes, _privilegedImages []string) (*client, error) {
 	// create Docker client from environment
 	//
@@ -66,7 +67,8 @@ func New(_volumes, _privilegedImages []string) (*client, error) {
 // integrates with a mock Docker runtime.
 //
 // This function is intended for running tests only.
-// nolint // ignore client error claiming it's annoying usage
+//
+// nolint: golint // ignore returning unexported client
 func NewMock() (*client, error) {
 	// create Docker client from the mock client
 	_docker, _ := mock.New()

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -54,7 +54,7 @@ func TestDocker_New(t *testing.T) {
 	}
 }
 
-// setup global variables used for testing
+// setup global variables used for testing.
 var (
 	_container = &pipeline.Container{
 		ID:          "step_github_octocat_1_clone",

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -102,6 +102,8 @@ func (c *client) RemoveContainer(ctx context.Context, ctn *pipeline.Container) e
 }
 
 // RunContainer creates and starts the pipeline container.
+//
+// nolint: funlen,lll // ignore function length and long line length
 func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *pipeline.Build) error {
 	logrus.Tracef("running container %s", ctn.ID)
 
@@ -278,6 +280,8 @@ func (c *client) SetupContainer(ctx context.Context, ctn *pipeline.Container) er
 }
 
 // TailContainer captures the logs for the pipeline container.
+//
+// nolint: lll // ignore long line length due to variable names
 func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io.ReadCloser, error) {
 	logrus.Tracef("tailing output for container %s", ctn.ID)
 
@@ -315,6 +319,8 @@ func (c *client) TailContainer(ctx context.Context, ctn *pipeline.Container) (io
 		reader := bufio.NewReader(stream)
 
 		// peek at container logs from the stream
+		//
+		// nolint: gomnd // ignore magic number
 		bytes, err := reader.Peek(5)
 		if err != nil {
 			// skip so we resend API call to capture stream

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -26,6 +26,8 @@ type client struct {
 
 // New returns an Engine implementation that
 // integrates with a Kubernetes runtime.
+//
+// nolint: golint // ignore returning unexported client
 func New(namespace, path string, _volumes, _privilegedImages []string) (*client, error) {
 	// use the current context in kubeconfig
 	//
@@ -62,6 +64,8 @@ func New(namespace, path string, _volumes, _privilegedImages []string) (*client,
 // integrates with a Kubernetes runtime.
 //
 // This function is intended for running tests only.
+//
+// nolint: golint // ignore returning unexported client
 func NewMock(_pod *v1.Pod) (*client, error) {
 	return &client{
 		namespace: "test",

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -50,7 +50,7 @@ func TestKubernetes_New(t *testing.T) {
 	}
 }
 
-// setup global variables used for testing
+// setup global variables used for testing.
 var (
 	_container = &pipeline.Container{
 		ID:          "step-github-octocat-1-clone",

--- a/runtime/kubernetes/network.go
+++ b/runtime/kubernetes/network.go
@@ -20,6 +20,7 @@ import (
 func (c *client) CreateNetwork(ctx context.Context, b *pipeline.Build) error {
 	logrus.Tracef("creating network for pipeline %s", b.ID)
 
+	// nolint: lll // ignore long line length due to link
 	// create the network for the pod
 	//
 	// This is done due to the nature of how networking works inside the

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// nolint: godot // ignore period at end for comment ending in a list
+//
 // New creates and returns a Vela engine capable of
 // integrating with the configured runtime.
 //


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues