### PR TITLE
refactor(docker): add ClientOpt{} and update New() to accept ...ClientOpt{}

### DIFF
--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -174,7 +174,7 @@ func TestDocker_RunContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine.hostConf = new(container.HostConfig)
+		_engine.HostConfig = new(container.HostConfig)
 
 		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
 

--- a/runtime/docker/docker_test.go
+++ b/runtime/docker/docker_test.go
@@ -38,7 +38,10 @@ func TestDocker_New(t *testing.T) {
 		// patch environment for tests
 		env.PatchAll(t, test.envs)
 
-		_, err := New(nil, nil)
+		_, err := New(
+			WithPrivilegedImages([]string{"alpine"}),
+			WithHostVolumes([]string{"/foo/bar.txt:/foo/bar.txt"}),
+		)
 
 		if test.failure {
 			if err == nil {

--- a/runtime/docker/image.go
+++ b/runtime/docker/image.go
@@ -39,7 +39,7 @@ func (c *client) CreateImage(ctx context.Context, ctn *pipeline.Container) error
 	// send API call to pull the image for the container
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.ImagePull
-	reader, err := c.docker.ImagePull(ctx, _image, opts)
+	reader, err := c.Docker.ImagePull(ctx, _image, opts)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (c *client) InspectImage(ctx context.Context, ctn *pipeline.Container) ([]b
 	// send API call to inspect the image
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.ImageInspectWithRaw
-	i, _, err := c.docker.ImageInspectWithRaw(ctx, _image)
+	i, _, err := c.Docker.ImageInspectWithRaw(ctx, _image)
 	if err != nil {
 		return output, err
 	}

--- a/runtime/docker/network.go
+++ b/runtime/docker/network.go
@@ -31,7 +31,7 @@ func (c *client) CreateNetwork(ctx context.Context, b *pipeline.Build) error {
 	// send API call to create the network
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.NetworkCreate
-	_, err := c.docker.NetworkCreate(ctx, b.ID, opts)
+	_, err := c.Docker.NetworkCreate(ctx, b.ID, opts)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (c *client) InspectNetwork(ctx context.Context, b *pipeline.Build) ([]byte,
 	// send API call to inspect the network
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.NetworkInspect
-	n, err := c.docker.NetworkInspect(ctx, b.ID, opts)
+	n, err := c.Docker.NetworkInspect(ctx, b.ID, opts)
 	if err != nil {
 		return output, err
 	}
@@ -80,7 +80,7 @@ func (c *client) RemoveNetwork(ctx context.Context, b *pipeline.Build) error {
 	// send API call to remove the network
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.NetworkRemove
-	err := c.docker.NetworkRemove(ctx, b.ID)
+	err := c.Docker.NetworkRemove(ctx, b.ID)
 	if err != nil {
 		return err
 	}

--- a/runtime/docker/opts.go
+++ b/runtime/docker/opts.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package docker
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// ClientOpt represents a configuration option to initialize the runtime client.
+type ClientOpt func(*client) error
+
+// WithPrivilegedImages sets the Docker privileged images in the runtime client.
+func WithPrivilegedImages(images []string) ClientOpt {
+	logrus.Trace("configuring privileged images in docker runtime client")
+
+	return func(c *client) error {
+		// set the runtime privileged images in the docker client
+		c.config.Images = images
+
+		return nil
+	}
+}
+
+// WithHostVolumes sets the Docker host volumes in the runtime client.
+func WithHostVolumes(volumes []string) ClientOpt {
+	logrus.Trace("configuring host volumes in docker runtime client")
+
+	return func(c *client) error {
+		// set the runtime host volumes in the docker client
+		c.config.Volumes = volumes
+
+		return nil
+	}
+}

--- a/runtime/docker/opts_test.go
+++ b/runtime/docker/opts_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package docker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDocker_ClientOpt_WithPrivilegedImages(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		images []string
+		want   []string
+	}{
+		{
+			images: []string{"alpine", "golang"},
+			want:   []string{"alpine", "golang"},
+		},
+		{
+			images: []string{},
+			want:   []string{},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_service, err := New(
+			WithPrivilegedImages(test.images),
+		)
+
+		if err != nil {
+			t.Errorf("WithPrivilegedImages returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_service.config.Images, test.want) {
+			t.Errorf("WithPrivilegedImages is %v, want %v", _service.config.Images, test.want)
+		}
+	}
+}
+
+func TestDocker_ClientOpt_WithHostVolumes(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		volumes []string
+		want    []string
+	}{
+		{
+			volumes: []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
+			want:    []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
+		},
+		{
+			volumes: []string{},
+			want:    []string{},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_service, err := New(
+			WithHostVolumes(test.volumes),
+		)
+
+		if err != nil {
+			t.Errorf("WithHostVolumes returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_service.config.Volumes, test.want) {
+			t.Errorf("WithHostVolumes is %v, want %v", _service.config.Volumes, test.want)
+		}
+	}
+}

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -25,7 +25,7 @@ func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 	logrus.Tracef("creating volume for pipeline %s", b.ID)
 
 	// create host configuration
-	c.hostConf = hostConfig(b.ID, c.volumes)
+	c.HostConfig = hostConfig(b.ID, c.config.Volumes)
 
 	// create options for creating volume
 	//
@@ -38,7 +38,7 @@ func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 	// send API call to create the volume
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.VolumeCreate
-	_, err := c.docker.VolumeCreate(ctx, opts)
+	_, err := c.Docker.VolumeCreate(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (c *client) InspectVolume(ctx context.Context, b *pipeline.Build) ([]byte, 
 	// send API call to inspect the volume
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.VolumeInspect
-	v, err := c.docker.VolumeInspect(ctx, b.ID)
+	v, err := c.Docker.VolumeInspect(ctx, b.ID)
 	if err != nil {
 		return output, err
 	}
@@ -82,7 +82,7 @@ func (c *client) RemoveVolume(ctx context.Context, b *pipeline.Build) error {
 	// send API call to remove the volume
 	//
 	// https://godoc.org/github.com/docker/docker/client#Client.VolumeRemove
-	err := c.docker.VolumeRemove(ctx, b.ID, true)
+	err := c.Docker.VolumeRemove(ctx, b.ID, true)
 	if err != nil {
 		return err
 	}

--- a/runtime/setup.go
+++ b/runtime/setup.go
@@ -35,7 +35,10 @@ func (s *Setup) Docker() (Engine, error) {
 	// create new Docker runtime engine
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime/docker?tab=doc#New
-	return docker.New(s.Volumes, s.PrivilegedImages)
+	return docker.New(
+		docker.WithPrivilegedImages(s.PrivilegedImages),
+		docker.WithHostVolumes(s.Volumes),
+	)
 }
 
 // Kubernetes creates and returns a Vela engine capable of


### PR DESCRIPTION
This adds a new way to create the `github.com/go-vela/pkg-runtime/runtime/docker` client used to integrate with Docker systems.

A `../../../runtime/docker.config{}` type has been added to store all required information to create the `docker` client:

https://github.com/go-vela/pkg-runtime/blob/76aa70e091127ad978fb453a5996bb77d70efbaf/runtime/docker/docker.go#L18-L23

A `../../../runtime/docker.ClientOpt{}` type has been added to set the fields in the `config{}` type:

https://github.com/go-vela/pkg-runtime/blob/76aa70e091127ad978fb453a5996bb77d70efbaf/runtime/docker/opts.go#L11-L12

Also updated the `../../../runtime/docker.New()` function to accept `...ClientOpt{}`:

https://github.com/go-vela/pkg-runtime/blob/76aa70e091127ad978fb453a5996bb77d70efbaf/runtime/docker/docker.go#L37-L79