### PR TITLE
refactor(kubernetes): add ClientOpt{} and update New() to accept ...ClientOpt{}

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -247,7 +247,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
 github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -298,7 +297,6 @@ github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -270,7 +270,7 @@ func TestKubernetes_WaitContainer(t *testing.T) {
 	_kubernetes.PrependWatchReactor("pods", reactor)
 
 	// overwrite the mock kubernetes client
-	_engine.kubernetes = _kubernetes
+	_engine.Kubernetes = _kubernetes
 
 	// setup tests
 	tests := []struct {

--- a/runtime/kubernetes/image.go
+++ b/runtime/kubernetes/image.go
@@ -56,7 +56,7 @@ func (c *client) InspectImage(ctx context.Context, ctn *pipeline.Container) ([]b
 	}
 
 	// marshal the image information from the container
-	image, err := json.MarshalIndent(c.pod.Spec.Containers[ctn.Number-2].Image, "", " ")
+	image, err := json.MarshalIndent(c.Pod.Spec.Containers[ctn.Number-2].Image, "", " ")
 	if err != nil {
 		return output, err
 	}

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -6,36 +6,57 @@ package kubernetes
 
 import (
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+type config struct {
+	// specifies the config file to use for the Kubernetes client
+	File string
+	// specifies the namespace to use for the Kubernetes client
+	Namespace string
+	// specifies a list of privileged images to use for the Kubernetes client
+	Images []string
+	// specifies a list of host volumes to use for the Kubernetes client
+	Volumes []string
+}
+
 type client struct {
-	kubernetes kubernetes.Interface
-
-	namespace string
-	pod       *v1.Pod
-
-	// set of host volumes to mount into every container
-	volumes []string
-	// set of images that are allowed to run in privileged mode
-	privilegedImages []string
+	config *config
+	// https://pkg.go.dev/k8s.io/client-go/kubernetes#Interface
+	Kubernetes kubernetes.Interface
+	// https://pkg.go.dev/k8s.io/api/core/v1#Pod
+	Pod *v1.Pod
 }
 
 // New returns an Engine implementation that
 // integrates with a Kubernetes runtime.
 //
 // nolint: golint // ignore returning unexported client
-func New(namespace, path string, _volumes, _privilegedImages []string) (*client, error) {
+func New(opts ...ClientOpt) (*client, error) {
+	// create new Kubernetes client
+	c := new(client)
+
+	// create new fields
+	c.config = new(config)
+	c.Pod = new(v1.Pod)
+
+	// apply all provided configuration options
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// use the current context in kubeconfig
 	//
 	// when kube config is provided use out of cluster config option else
 	// function will build and return an InClusterConfig
 	//
 	// https://pkg.go.dev/k8s.io/client-go/tools/clientcmd?tab=doc#BuildConfigFromFlags
-	config, err := clientcmd.BuildConfigFromFlags("", path)
+	config, err := clientcmd.BuildConfigFromFlags("", c.config.File)
 	if err != nil {
 		return nil, err
 	}
@@ -48,16 +69,10 @@ func New(namespace, path string, _volumes, _privilegedImages []string) (*client,
 		return nil, err
 	}
 
-	// create the client object
-	return &client{
-		namespace: namespace,
-		pod: &v1.Pod{
-			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
-		},
-		kubernetes:       _kubernetes,
-		volumes:          _volumes,
-		privilegedImages: _privilegedImages,
-	}, nil
+	// set the Kubernetes client in the runtime client
+	c.Kubernetes = _kubernetes
+
+	return c, nil
 }
 
 // NewMock returns an Engine implementation that
@@ -66,12 +81,32 @@ func New(namespace, path string, _volumes, _privilegedImages []string) (*client,
 // This function is intended for running tests only.
 //
 // nolint: golint // ignore returning unexported client
-func NewMock(_pod *v1.Pod) (*client, error) {
-	return &client{
-		namespace: "test",
-		pod:       _pod,
-		// https://pkg.go.dev/k8s.io/client-go/kubernetes/fake?tab=doc#NewSimpleClientset
-		kubernetes:       fake.NewSimpleClientset(_pod),
-		privilegedImages: []string{"target/vela-git"},
-	}, nil
+func NewMock(_pod *v1.Pod, opts ...ClientOpt) (*client, error) {
+	// create new Kubernetes client
+	c := new(client)
+
+	// create new fields
+	c.config = new(config)
+	c.Pod = new(v1.Pod)
+
+	// set the Kubernetes namespace in the runtime client
+	c.config.Namespace = "test"
+
+	// set the Kubernetes pod in the runtime client
+	c.Pod = _pod
+
+	// apply all provided configuration options
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// set the Kubernetes fake client in the runtime client
+	//
+	// https://pkg.go.dev/k8s.io/client-go/kubernetes/fake?tab=doc#NewSimpleClientset
+	c.Kubernetes = fake.NewSimpleClientset(c.Pod)
+
+	return c, nil
 }

--- a/runtime/kubernetes/kubernetes_test.go
+++ b/runtime/kubernetes/kubernetes_test.go
@@ -34,7 +34,10 @@ func TestKubernetes_New(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_, err := New(test.namespace, test.path, nil, nil)
+		_, err := New(
+			WithConfigFile(test.path),
+			WithNamespace(test.namespace),
+		)
 
 		if test.failure {
 			if err == nil {

--- a/runtime/kubernetes/network.go
+++ b/runtime/kubernetes/network.go
@@ -82,7 +82,7 @@ func (c *client) CreateNetwork(ctx context.Context, b *pipeline.Build) error {
 	// add the network definition to the pod spec
 	//
 	// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodSpec
-	c.pod.Spec.HostAliases = append(c.pod.Spec.HostAliases, network)
+	c.Pod.Spec.HostAliases = append(c.Pod.Spec.HostAliases, network)
 
 	return nil
 }
@@ -99,7 +99,7 @@ func (c *client) InspectNetwork(ctx context.Context, b *pipeline.Build) ([]byte,
 	)
 
 	// marshal the network information from the pod
-	network, err := json.MarshalIndent(c.pod.Spec.HostAliases, "", " ")
+	network, err := json.MarshalIndent(c.Pod.Spec.HostAliases, "", " ")
 	if err != nil {
 		return output, err
 	}
@@ -118,7 +118,7 @@ func (c *client) RemoveNetwork(ctx context.Context, b *pipeline.Build) error {
 	// remove the network definition from the pod spec
 	//
 	// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodSpec
-	c.pod.Spec.HostAliases = []v1.HostAlias{}
+	c.Pod.Spec.HostAliases = []v1.HostAlias{}
 
 	return nil
 }

--- a/runtime/kubernetes/opts.go
+++ b/runtime/kubernetes/opts.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ClientOpt represents a configuration option to initialize the runtime client.
+type ClientOpt func(*client) error
+
+// WithConfigFile sets the Kubernetes config file in the runtime client.
+func WithConfigFile(file string) ClientOpt {
+	logrus.Trace("configuring config file in kubernetes runtime client")
+
+	return func(c *client) error {
+		// set the runtime config file in the kubernetes client
+		c.config.File = file
+
+		return nil
+	}
+}
+
+// WithNamespace sets the Kubernetes namespace in the runtime client.
+func WithNamespace(namespace string) ClientOpt {
+	logrus.Trace("configuring namespace in kubernetes runtime client")
+
+	return func(c *client) error {
+		// check if the namespace provided is empty
+		if len(namespace) == 0 {
+			return fmt.Errorf("no Kubernetes namespace provided")
+		}
+
+		// set the runtime namespace in the kubernetes client
+		c.config.Namespace = namespace
+
+		return nil
+	}
+}
+
+// WithPrivilegedImages sets the Kubernetes privileged images in the runtime client.
+func WithPrivilegedImages(images []string) ClientOpt {
+	logrus.Trace("configuring privileged images in kubernetes runtime client")
+
+	return func(c *client) error {
+		// set the runtime privileged images in the kubernetes client
+		c.config.Images = images
+
+		return nil
+	}
+}
+
+// WithHostVolumes sets the Kubernetes host volumes in the runtime client.
+func WithHostVolumes(volumes []string) ClientOpt {
+	logrus.Trace("configuring host volumes in kubernetes runtime client")
+
+	return func(c *client) error {
+		// set the runtime host volumes in the kubernetes client
+		c.config.Volumes = volumes
+
+		return nil
+	}
+}

--- a/runtime/kubernetes/opts_test.go
+++ b/runtime/kubernetes/opts_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKubernetes_ClientOpt_WithConfigFile(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure bool
+		file    string
+		want    string
+	}{
+		{
+			failure: false,
+			file:    "testdata/config",
+			want:    "testdata/config",
+		},
+		{
+			failure: true,
+			file:    "",
+			want:    "",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithConfigFile(test.file),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithConfigFile should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithConfigFile returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.config.File, test.want) {
+			t.Errorf("WithConfigFile is %v, want %v", _engine.config.File, test.want)
+		}
+	}
+}
+
+func TestKubernetes_ClientOpt_WithNamespace(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure   bool
+		namespace string
+		want      string
+	}{
+		{
+			failure:   false,
+			namespace: "foo",
+			want:      "foo",
+		},
+		{
+			failure:   true,
+			namespace: "",
+			want:      "",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithConfigFile("testdata/config"),
+			WithNamespace(test.namespace),
+		)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("WithNamespace should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("WithNamespace returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.config.Namespace, test.want) {
+			t.Errorf("WithNamespace is %v, want %v", _engine.config.Namespace, test.want)
+		}
+	}
+}
+
+func TestKubernetes_ClientOpt_WithHostVolumes(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		volumes []string
+		want    []string
+	}{
+		{
+			volumes: []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
+			want:    []string{"/foo/bar.txt:/foo/bar.txt", "/tmp/baz.conf:/tmp/baz.conf"},
+		},
+		{
+			volumes: []string{},
+			want:    []string{},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithConfigFile("testdata/config"),
+			WithHostVolumes(test.volumes),
+		)
+
+		if err != nil {
+			t.Errorf("WithHostVolumes returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.config.Volumes, test.want) {
+			t.Errorf("WithHostVolumes is %v, want %v", _engine.config.Volumes, test.want)
+		}
+	}
+}
+
+func TestKubernetes_ClientOpt_WithPrivilegedImages(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		images []string
+		want   []string
+	}{
+		{
+			images: []string{"alpine", "golang"},
+			want:   []string{"alpine", "golang"},
+		},
+		{
+			images: []string{},
+			want:   []string{},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_engine, err := New(
+			WithConfigFile("testdata/config"),
+			WithPrivilegedImages(test.images),
+		)
+
+		if err != nil {
+			t.Errorf("WithPrivilegedImages returned err: %v", err)
+		}
+
+		if !reflect.DeepEqual(_engine.config.Images, test.want) {
+			t.Errorf("WithPrivilegedImages is %v, want %v", _engine.config.Images, test.want)
+		}
+	}
+}

--- a/runtime/kubernetes/volume.go
+++ b/runtime/kubernetes/volume.go
@@ -46,17 +46,17 @@ func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 	// add the volume definition to the pod spec
 	//
 	// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodSpec
-	c.pod.Spec.Volumes = append(c.pod.Spec.Volumes, volume)
+	c.Pod.Spec.Volumes = append(c.Pod.Spec.Volumes, volume)
 
 	// check if other volumes were provided
-	if len(c.volumes) > 0 {
+	if len(c.config.Volumes) > 0 {
 		// iterate through all volumes provided
-		for k, v := range c.volumes {
+		for k, v := range c.config.Volumes {
 			// parse the volume provided
 			_volume := vol.Parse(v)
 
 			// add the volume to the set of pod volumes
-			c.pod.Spec.Volumes = append(c.pod.Spec.Volumes, v1.Volume{
+			c.Pod.Spec.Volumes = append(c.Pod.Spec.Volumes, v1.Volume{
 				Name: fmt.Sprintf("%s_%d", b.ID, k),
 				VolumeSource: v1.VolumeSource{
 					HostPath: &v1.HostPathVolumeSource{
@@ -82,7 +82,7 @@ func (c *client) InspectVolume(ctx context.Context, b *pipeline.Build) ([]byte, 
 	)
 
 	// marshal the volume information from the pod
-	volume, err := json.MarshalIndent(c.pod.Spec.Volumes, "", " ")
+	volume, err := json.MarshalIndent(c.Pod.Spec.Volumes, "", " ")
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *client) RemoveVolume(ctx context.Context, b *pipeline.Build) error {
 	// remove the volume definition from the pod spec
 	//
 	// https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#PodSpec
-	c.pod.Spec.Volumes = []v1.Volume{}
+	c.Pod.Spec.Volumes = []v1.Volume{}
 
 	return nil
 }

--- a/runtime/setup.go
+++ b/runtime/setup.go
@@ -46,7 +46,12 @@ func (s *Setup) Kubernetes() (Engine, error) {
 	// create new Kubernetes runtime engine
 	//
 	// https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime/kubernetes?tab=doc#New
-	return kubernetes.New(s.Namespace, s.Config, s.Volumes, s.PrivilegedImages)
+	return kubernetes.New(
+		kubernetes.WithConfigFile(s.Config),
+		kubernetes.WithNamespace(s.Namespace),
+		kubernetes.WithPrivilegedImages(s.PrivilegedImages),
+		kubernetes.WithHostVolumes(s.Volumes),
+	)
 }
 
 // Validate verifies the necessary fields for the


### PR DESCRIPTION
This adds a new way to create the `github.com/go-vela/pkg-runtime/runtime/kubernetes` client used to integrate with Kubernetes systems.

A `../../../runtime/kubernetes.config{}` type has been added to store all required information to create the `kubernetes` client:

https://github.com/go-vela/pkg-runtime/blob/4a62adc3f706b85276703ab7ad7d86df1bdd45b7/runtime/kubernetes/kubernetes.go#L14-L23

A `../../../runtime/kubernetes.ClientOpt{}` type has been added to set the fields in the `config{}` type:

https://github.com/go-vela/pkg-runtime/blob/4a62adc3f706b85276703ab7ad7d86df1bdd45b7/runtime/kubernetes/opts.go#L13-L14

Also updated the `../../../runtime/kubernetes.New()` function to accept `...ClientOpt{}`:

https://github.com/go-vela/pkg-runtime/blob/4a62adc3f706b85276703ab7ad7d86df1bdd45b7/runtime/kubernetes/kubernetes.go#L33-L76