### PR TITLE
refactor!: creating runtime client with setup

### DIFF
--- a/cmd/vela-runtime/run.go
+++ b/cmd/vela-runtime/run.go
@@ -55,9 +55,9 @@ func run(c *cli.Context) error {
 
 	// setup the runtime
 	r, err := runtime.New(&runtime.Setup{
-		Driver:    c.String("runtime.driver"),
-		Config:    c.String("runtime.config"),
-		Namespace: c.String("runtime.namespace"),
+		Driver:     c.String("runtime.driver"),
+		ConfigFile: c.String("runtime.config"),
+		Namespace:  c.String("runtime.namespace"),
 	})
 	if err != nil {
 		logrus.Fatal(err)

--- a/runtime/flags.go
+++ b/runtime/flags.go
@@ -19,9 +19,15 @@ var Flags = []cli.Flag{
 	// Logging Flags
 
 	&cli.StringFlag{
-		EnvVars: []string{"RUNTIME_LOG_LEVEL", "VELA_LOG_LEVEL", "LOG_LEVEL"},
+		EnvVars: []string{"VELA_LOG_FORMAT", "RUNTIME_LOG_FORMAT"},
+		Name:    "runtime.log.format",
+		Usage:   "format of logs to output",
+		Value:   "json",
+	},
+	&cli.StringFlag{
+		EnvVars: []string{"VELA_LOG_LEVEL", "RUNTIME_LOG_LEVEL"},
 		Name:    "runtime.log.level",
-		Usage:   "set log level - options: (trace|debug|info|warn|error|fatal|panic)",
+		Usage:   "level of logs to output",
 		Value:   "info",
 	},
 
@@ -30,27 +36,27 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		EnvVars: []string{"VELA_RUNTIME_DRIVER", "RUNTIME_DRIVER"},
 		Name:    "runtime.driver",
-		Usage:   "name of runtime driver to use",
+		Usage:   "driver to be used for the runtime",
 		Value:   constants.DriverDocker,
 	},
 	&cli.StringFlag{
 		EnvVars: []string{"VELA_RUNTIME_CONFIG", "RUNTIME_CONFIG"},
 		Name:    "runtime.config",
-		Usage:   "path to runtime configuration file",
+		Usage:   "path to configuration file for the runtime",
 	},
 	&cli.StringFlag{
 		EnvVars: []string{"VELA_RUNTIME_NAMESPACE", "RUNTIME_NAMESPACE"},
 		Name:    "runtime.namespace",
-		Usage:   "name of namespace for runtime configuration (kubernetes runtime only)",
+		Usage:   "namespace to use for the runtime (only used by kubernetes)",
+	},
+	&cli.StringSliceFlag{
+		EnvVars: []string{"VELA_RUNTIME_PRIVILEGED_IMAGES", "RUNTIME_PRIVILEGED_IMAGES"},
+		Name:    "runtime.privileged-images",
+		Usage:   "list of images allowed to run in privileged mode for the runtime",
 	},
 	&cli.StringSliceFlag{
 		EnvVars: []string{"VELA_RUNTIME_VOLUMES", "RUNTIME_VOLUMES"},
 		Name:    "runtime.volumes",
-		Usage:   "set of volumes to mount into the runtime",
-	},
-	&cli.StringSliceFlag{
-		EnvVars: []string{"VELA_ALLOWED_PRIVILEGED_IMAGES", "RUNTIME_VOLUMES"},
-		Name:    "runtime.allowed-privileged-images",
-		Usage:   "set of images that are allowed to run in privileged mode",
+		Usage:   "list of host volumes to mount for the runtime",
 	},
 }

--- a/runtime/flags.go
+++ b/runtime/flags.go
@@ -53,6 +53,7 @@ var Flags = []cli.Flag{
 		EnvVars: []string{"VELA_RUNTIME_PRIVILEGED_IMAGES", "RUNTIME_PRIVILEGED_IMAGES"},
 		Name:    "runtime.privileged-images",
 		Usage:   "list of images allowed to run in privileged mode for the runtime",
+		Value:   cli.NewStringSlice("target/vela-docker"),
 	},
 	&cli.StringSliceFlag{
 		EnvVars: []string{"VELA_RUNTIME_VOLUMES", "RUNTIME_VOLUMES"},

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -41,7 +41,7 @@ func New(s *Setup) (Engine, error) {
 	case constants.DriverKubernetes:
 		// handle the Kubernetes runtime driver being provided
 		//
-		// // https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime?tab=doc#Setup.Kubernetes
+		// https://pkg.go.dev/github.com/go-vela/pkg-runtime/runtime?tab=doc#Setup.Kubernetes
 		return s.Kubernetes()
 	default:
 		// handle an invalid runtime driver being provided

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -25,9 +25,9 @@ func TestRuntime_New(t *testing.T) {
 		{
 			failure: false,
 			setup: &Setup{
-				Driver:    constants.DriverKubernetes,
-				Namespace: "docker",
-				Config:    "testdata/config",
+				Driver:     constants.DriverKubernetes,
+				Namespace:  "docker",
+				ConfigFile: "testdata/config",
 			},
 		},
 		{

--- a/runtime/setup_test.go
+++ b/runtime/setup_test.go
@@ -26,9 +26,9 @@ func TestRuntime_Setup_Docker(t *testing.T) {
 func TestRuntime_Setup_Kubernetes(t *testing.T) {
 	// setup types
 	_setup := &Setup{
-		Driver:    constants.DriverKubernetes,
-		Namespace: "docker",
-		Config:    "testdata/config",
+		Driver:     constants.DriverKubernetes,
+		ConfigFile: "testdata/config",
+		Namespace:  "docker",
 	}
 
 	// run test


### PR DESCRIPTION
This is a BREAKING CHANGE and contains a generic refactor for the `github.com/go-vela/pkg-runtime/runtime` package:

* Added a `runtime.log.format` flag with a default value of `json`
* Switched flag `runtime.allowed-privileged-images` -> `runtime.privileged-images`
  * environment variable `VELA_ALLOWED_PRIVILEGED_IMAGES` -> `VELA_RUNTIME_PRIVILEGED_IMAGES`
  * added the environment variable `RUNTIME_PRIVILEGED_IMAGES`
* Added [the `target/vela-docker` plugin](https://github.com/go-vela/vela-docker) as the default for `runtime.privileged-images`
* Enhanced descriptions for almost all flags
* Added descriptions for the fields in the `../../pkg-runtime/runtime.Setup{}` type
* Switched the `../../../runtime.Setup.Config` field -> `../../../runtime.Setup.ConfigFile`
* Switched the `../../../runtime.Setup.Volumes` field -> `../../../runtime.Setup.HostVolumes`
* Refactored the `../../../runtime.Setup.Validate()` function to improve test coverage