### PR TITLE
fix(kaniko): add workaround for private cert bind mounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-vela/mock v0.7.5-0.20210416160452-fa8721fcc6a1
 	github.com/go-vela/types v0.7.4
 	github.com/joho/godotenv v1.3.0
-	github.com/opencontainers/image-spec v1.0.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli/v2 v2.3.0
 	google.golang.org/genproto v0.0.0-20201013134114-7f9ee70cb474 // indirect

--- a/runtime/docker/container.go
+++ b/runtime/docker/container.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/go-vela/types/constants"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -173,7 +172,7 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 		c.ContainerConfig,
 		hostConf,
 		c.NetworkConfig,
-		&v1.Platform{},
+		nil,
 		ctn.ID,
 	)
 	if err != nil {

--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -116,6 +116,7 @@ func TestDocker_RunContainer(t *testing.T) {
 		failure   bool
 		pipeline  *pipeline.Build
 		container *pipeline.Container
+		volumes   []string
 	}{
 		{
 			failure:   false,
@@ -153,6 +154,22 @@ func TestDocker_RunContainer(t *testing.T) {
 			},
 		},
 		{
+			failure:  false,
+			pipeline: _pipeline,
+			container: &pipeline.Container{
+				ID:          "step_github_octocat_1_echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "target/vela-kaniko:latest",
+				Name:        "echo",
+				Number:      2,
+				Pull:        "always",
+			},
+			volumes: []string{"/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:rw"},
+		},
+		{
 			failure:   true,
 			pipeline:  _pipeline,
 			container: new(pipeline.Container),
@@ -175,6 +192,10 @@ func TestDocker_RunContainer(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		_engine.HostConfig = new(container.HostConfig)
+
+		if len(test.volumes) > 0 {
+			_engine.config.Volumes = test.volumes
+		}
 
 		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
 

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -145,6 +145,35 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 					})
 				}
 			}
+
+			// -------------------- Start of TODO: --------------------
+			//
+			// Remove the below code once the mounting issue with Kaniko is
+			// resolved to allow mounting private cert bundles with Vela.
+			//
+			// This code is required due to a known bug in Kaniko:
+			//
+			// * https://github.com/go-vela/community/issues/253
+
+			// check if the pipeline container image contains
+			// the key words "kaniko" and "vela"
+			//
+			// this is a soft check for the Vela Kaniko plugin
+			if strings.Contains(ctn.Image, "kaniko") &&
+				strings.Contains(ctn.Image, "vela") {
+				// iterate through the list of host mounts provided
+				for i, mount := range container.VolumeMounts {
+					// check if the path for the mount contains "/etc/ssl/certs"
+					//
+					// this is a soft check for mounting private cert bundles
+					if strings.Contains(mount.MountPath, "/etc/ssl/certs") {
+						// remove the private cert bundle mount from the host config
+						container.VolumeMounts = append(container.VolumeMounts[:i], container.VolumeMounts[i+1:]...)
+					}
+				}
+			}
+			//
+			// -------------------- End of TODO: --------------------
 		}
 
 		// create the object metadata for the pod

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -101,6 +101,7 @@ func TestKubernetes_RunContainer(t *testing.T) {
 		container *pipeline.Container
 		pipeline  *pipeline.Build
 		pod       *v1.Pod
+		volumes   []string
 	}{
 		{
 			failure:   false,
@@ -141,6 +142,38 @@ func TestKubernetes_RunContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			failure: false,
+			container: &pipeline.Container{
+				ID:          "step-github-octocat-1-echo",
+				Commands:    []string{"echo", "hello"},
+				Directory:   "/vela/src/github.com/octocat/helloworld",
+				Environment: map[string]string{"FOO": "bar"},
+				Entrypoint:  []string{"/bin/sh", "-c"},
+				Image:       "target/vela-kaniko:latest",
+				Name:        "echo",
+				Number:      2,
+				Pull:        "always",
+			},
+			pipeline: _steps,
+			pod: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "step-github-octocat-1-echo",
+							Image:           "target/vela-kaniko:latest",
+							WorkingDir:      "/vela/src/github.com/octocat/helloworld",
+							ImagePullPolicy: v1.PullAlways,
+						},
+					},
+				},
+			},
+			volumes: []string{"/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:rw"},
+		},
 	}
 
 	// run tests
@@ -148,6 +181,10 @@ func TestKubernetes_RunContainer(t *testing.T) {
 		_engine, err := NewMock(test.pod)
 		if err != nil {
 			t.Errorf("unable to create runtime engine: %v", err)
+		}
+
+		if len(test.volumes) > 0 {
+			_engine.config.Volumes = test.volumes
 		}
 
 		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/253

This change adds a workaround for the Vela Kaniko plugin when utilizing bind mounts for private cert bundles.

This works by searching for special keywords in the `image` field for a `step` in a pipeline.

If both the keywords `vela` and `kaniko` exist in that `image`, we then traverse through the list of host volumes.

While iterating through that list of volumes to mount from the host, if a volume contains `/etc/ssl/certs`, it is removed.

The end result would prevent the Vela worker from mounting `/etc/ssl/certs/ca-certificates.crt` into that step.