### PR TITLE
fix(docker): use ephemeral configs for containers

### DIFF
--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/go-vela/types/pipeline"
 )
 
@@ -191,8 +190,6 @@ func TestDocker_RunContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine.HostConfig = new(container.HostConfig)
-
 		if len(test.volumes) > 0 {
 			_engine.config.Volumes = test.volumes
 		}

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -5,8 +5,6 @@
 package docker
 
 import (
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
 
 	mock "github.com/go-vela/mock/docker"
@@ -40,12 +38,6 @@ type client struct {
 	config *config
 	// https://godoc.org/github.com/docker/docker/client#CommonAPIClient
 	Docker docker.CommonAPIClient
-	// https://godoc.org/github.com/docker/docker/api/types/container#Config
-	ContainerConfig *container.Config
-	// https://godoc.org/github.com/docker/docker/api/types/container#HostConfig
-	HostConfig *container.HostConfig
-	// https://godoc.org/github.com/docker/docker/api/types/network#NetworkingConfig
-	NetworkConfig *network.NetworkingConfig
 }
 
 // New returns an Engine implementation that
@@ -58,9 +50,6 @@ func New(opts ...ClientOpt) (*client, error) {
 
 	// create new fields
 	c.config = new(config)
-	c.ContainerConfig = new(container.Config)
-	c.HostConfig = new(container.HostConfig)
-	c.NetworkConfig = new(network.NetworkingConfig)
 
 	// apply all provided configuration options
 	for _, opt := range opts {

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -24,9 +24,6 @@ import (
 func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 	logrus.Tracef("creating volume for pipeline %s", b.ID)
 
-	// create host configuration
-	c.HostConfig = hostConfig(b.ID, c.config.Volumes)
-
 	// create options for creating volume
 	//
 	// https://godoc.org/github.com/docker/docker/api/types/volume#VolumeCreateBody


### PR DESCRIPTION
Related to https://github.com/go-vela/pkg-runtime/pull/98

This will ensure usage of ephemeral configurations when attempting to create containers for the `docker` runtime.

These configurations for a container store information about Vela's step resource.

They contain the commands, environment variables, entrypoint etc. for that container to pass to Docker.

Under certain conditions, this resolves an issue where the configuration for a container is mixed up with another container.

## Context

Currently, these configurations are stored as fields  in the `docker` runtime client:

https://github.com/go-vela/pkg-runtime/blob/57eb15a12186127ee74c10f580ea2b4b1dae8719/runtime/docker/docker.go#L43-L48

These configurations are populated with actual values throughout the lifecycle of a build:

https://github.com/go-vela/pkg-runtime/blob/57eb15a12186127ee74c10f580ea2b4b1dae8719/runtime/docker/volume.go#L27-L28

https://github.com/go-vela/pkg-runtime/blob/57eb15a12186127ee74c10f580ea2b4b1dae8719/runtime/docker/container.go#L151-L153

When runtime containers are created, these configurations are passed to the Docker API:

https://github.com/go-vela/pkg-runtime/blob/57eb15a12186127ee74c10f580ea2b4b1dae8719/runtime/docker/container.go#L167-L177

This can create a problem when attempting to run processes in parallel (i.e. create multiple containers at the same time).

The end behavior experienced is the configurations for one container may be re-used for another container.

## Solution

The resolution to this is creating new, locally scoped, variables to store these ephemeral configurations:

https://github.com/go-vela/pkg-runtime/blob/46fee8425079313332c793ceeedf73a8ffb065bd/runtime/docker/container.go#L99-L104

And then passing those local variables to the Docker APIs instead of the fields stored in the client:

https://github.com/go-vela/pkg-runtime/blob/46fee8425079313332c793ceeedf73a8ffb065bd/runtime/docker/container.go#L158-L168

> NOTE:
>
> I removed the configuration fields from the `docker` runtime client as they aren't used anywhere else.