### PR TITLE
fix(docker): use ephemeral configs for containers

### DIFF
--- a/runtime/docker/container_test.go
+++ b/runtime/docker/container_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/go-vela/types/pipeline"
 )
 
@@ -174,8 +173,6 @@ func TestDocker_RunContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		_engine.hostConf = new(container.HostConfig)
-
 		err = _engine.RunContainer(context.Background(), test.container, test.pipeline)
 
 		if test.failure {

--- a/runtime/docker/docker.go
+++ b/runtime/docker/docker.go
@@ -5,8 +5,6 @@
 package docker
 
 import (
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
 
 	mock "github.com/go-vela/mock/docker"
@@ -18,13 +16,6 @@ const version = "1.40"
 type client struct {
 	// https://godoc.org/github.com/docker/docker/client#CommonAPIClient
 	docker docker.CommonAPIClient
-
-	// https://godoc.org/github.com/docker/docker/api/types/container#Config
-	ctnConf *container.Config
-	// https://godoc.org/github.com/docker/docker/api/types/container#HostConfig
-	hostConf *container.HostConfig
-	// https://godoc.org/github.com/docker/docker/api/types/network#NetworkingConfig
-	netConf *network.NetworkingConfig
 
 	// set of host volumes to mount into every container
 	volumes []string
@@ -55,9 +46,6 @@ func New(_volumes, _privilegedImages []string) (*client, error) {
 
 	return &client{
 		docker:           _docker,
-		ctnConf:          new(container.Config),
-		hostConf:         new(container.HostConfig),
-		netConf:          new(network.NetworkingConfig),
 		volumes:          _volumes,
 		privilegedImages: _privilegedImages,
 	}, nil

--- a/runtime/docker/volume.go
+++ b/runtime/docker/volume.go
@@ -24,9 +24,6 @@ import (
 func (c *client) CreateVolume(ctx context.Context, b *pipeline.Build) error {
 	logrus.Tracef("creating volume for pipeline %s", b.ID)
 
-	// create host configuration
-	c.hostConf = hostConfig(b.ID, c.volumes)
-
 	// create options for creating volume
 	//
 	// https://godoc.org/github.com/docker/docker/api/types/volume#VolumeCreateBody


### PR DESCRIPTION
This is a backport of https://github.com/go-vela/pkg-runtime/pull/114 for the `v0.7.x` release.

For more details, please review the above PR.

Related to https://github.com/go-vela/pkg-runtime/pull/98

This will ensure usage of ephemeral configurations when attempting to create containers for the docker runtime.

These configurations for a container store information about Vela's step resource.

They contain the commands, environment variables, entrypoint etc. for that container to pass to Docker.

Under certain conditions, this resolves an issue where the configuration for a container is mixed up with another container.