### PR TITLE
fix(k8s): Refactor RunContainer to move setup logic elsewhere

### DIFF
--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -110,7 +110,7 @@ func (c *client) RemoveContainer(ctx context.Context, ctn *pipeline.Container) e
 
 // RunContainer creates and starts the pipeline container.
 //
-// nolint: funlen,lll // ignore function length and long line length
+// nolint: lll // ignore long line length
 func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *pipeline.Build) error {
 	logrus.Tracef("running container %s", ctn.ID)
 

--- a/runtime/kubernetes/container.go
+++ b/runtime/kubernetes/container.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/go-vela/pkg-runtime/internal/image"
-	vol "github.com/go-vela/pkg-runtime/internal/volume"
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 
@@ -123,28 +122,8 @@ func (c *client) RunContainer(ctx context.Context, ctn *pipeline.Container, b *p
 		//
 		// iterate through each container in the pod
 		for _, container := range c.Pod.Spec.Containers {
-			// update the container with the volume to mount
-			container.VolumeMounts = []v1.VolumeMount{
-				{
-					Name:      b.ID,
-					MountPath: constants.WorkspaceMount,
-				},
-			}
-
-			// check if other volumes were provided
-			if len(c.config.Volumes) > 0 {
-				// iterate through all volumes provided
-				for k, v := range c.config.Volumes {
-					// parse the volume provided
-					_volume := vol.Parse(v)
-
-					// add the volume to the container
-					container.VolumeMounts = append(container.VolumeMounts, v1.VolumeMount{
-						Name:      fmt.Sprintf("%s_%d", b.ID, k),
-						MountPath: _volume.Destination,
-					})
-				}
-			}
+			// add workspace mount and any global host mounts (VELA_RUNTIME_VOLUMES)
+			container.VolumeMounts = c.commonVolumeMounts[:]
 
 			// -------------------- Start of TODO: --------------------
 			//

--- a/runtime/kubernetes/container_test.go
+++ b/runtime/kubernetes/container_test.go
@@ -95,6 +95,7 @@ func TestKubernetes_RemoveContainer(t *testing.T) {
 }
 
 func TestKubernetes_RunContainer(t *testing.T) {
+	// TODO: include VolumeMounts?
 	// setup tests
 	tests := []struct {
 		failure   bool
@@ -253,6 +254,8 @@ func TestKubernetes_SetupContainer(t *testing.T) {
 	for _, test := range tests {
 		err = _engine.SetupContainer(context.Background(), test.container)
 
+		// this does not test the resulting pod spec (ie no tests for ImagePullPolicy, VolumeMounts)
+
 		if test.failure {
 			if err == nil {
 				t.Errorf("SetupContainer should have returned err")
@@ -277,6 +280,7 @@ func TestKubernetes_TailContainer(t *testing.T) {
 	// always returned when calling the GetLogs function.
 	//
 	// https://github.com/kubernetes/kubernetes/issues/84203
+	// fixed in k8s.io/client-go v0.19.0; we already have v0.22.2
 }
 
 func TestKubernetes_WaitContainer(t *testing.T) {

--- a/runtime/kubernetes/kubernetes.go
+++ b/runtime/kubernetes/kubernetes.go
@@ -30,6 +30,8 @@ type client struct {
 	Kubernetes kubernetes.Interface
 	// https://pkg.go.dev/k8s.io/api/core/v1#Pod
 	Pod *v1.Pod
+	// commonVolumeMounts includes workspace mount and any global host mounts (VELA_RUNTIME_VOLUMES)
+	commonVolumeMounts []v1.VolumeMount
 }
 
 // New returns an Engine implementation that

--- a/runtime/kubernetes/volume.go
+++ b/runtime/kubernetes/volume.go
@@ -129,6 +129,7 @@ func (c *client) RemoveVolume(ctx context.Context, b *pipeline.Build) error {
 }
 
 // setupVolumeMounts generates the VolumeMounts for a given container.
+// nolint:unparam // keep signature similar to Engine interface methods despite unused ctx and err
 func (c *client) setupVolumeMounts(ctx context.Context, ctn *pipeline.Container) (
 	volumeMounts []v1.VolumeMount,
 	err error,

--- a/runtime/kubernetes/volume.go
+++ b/runtime/kubernetes/volume.go
@@ -129,7 +129,10 @@ func (c *client) RemoveVolume(ctx context.Context, b *pipeline.Build) error {
 }
 
 // setupVolumeMounts generates the VolumeMounts for a given container.
-func (c *client) setupVolumeMounts(ctx context.Context, ctn *pipeline.Container) (volumeMounts []v1.VolumeMount, err error) {
+func (c *client) setupVolumeMounts(ctx context.Context, ctn *pipeline.Container) (
+	volumeMounts []v1.VolumeMount,
+	err error,
+) {
 	logrus.Tracef("setting up VolumeMounts for container %s", ctn.ID)
 
 	// add workspace mount and any global host mounts (VELA_RUNTIME_VOLUMES)
@@ -166,5 +169,5 @@ func (c *client) setupVolumeMounts(ctx context.Context, ctn *pipeline.Container)
 
 	// TODO: extend volumeMounts based on ctn.Volumes
 
-	return
+	return volumeMounts, nil
 }


### PR DESCRIPTION
Both `VolumeMounts` and `ImagePullPolicy` are immutable, so they cannot be updated after pod creation.

This PR moves the logic that defines the `VolumeMounts` next to the `Volume` definitions.
It also moves the `ImagePullPolicy` definition from `RunContainer` to `SetupContainer`.